### PR TITLE
proxy: fix rabbit topics reconnect

### DIFF
--- a/est-proxy/src/repository/rabbit.go
+++ b/est-proxy/src/repository/rabbit.go
@@ -1,5 +1,7 @@
 package repository
 
+import "github.com/rabbitmq/amqp091-go"
+
 type RabbitRepository interface {
 	GetTopic(name string) Topic
 	Refresh()
@@ -9,6 +11,7 @@ type RabbitRepository interface {
 type Topic interface {
 	Publish(message []byte) error
 	Subscribe(handler Callback) error
+	Reconnect(channel *amqp091.Channel) error
 }
 
 type Callback func(message []byte)


### PR DESCRIPTION
Была проблема реконнекта рэббита, при которой он не отправлял сообщения после, соответственно, переподключения. Суть была в том, что переподключался только канал, но не топики.